### PR TITLE
Fixing an error when multiple items use add clear

### DIFF
--- a/addclear.js
+++ b/addclear.js
@@ -15,7 +15,7 @@
 				}, options);
 
 				$(this).wrap("<span style='position:relative;' class='add-clear-span'>");
-				$(".add-clear-span").append("<a href='#clear'>clear</a>");
+				$(this).after("<a href='#clear'>clear</a>");
 				$("a[href='#clear']").css({
 					'background' : 'transparent url('+options.closeImage+') 0 0 no-repeat', 
 					'display' : 'none',


### PR DESCRIPTION
If multiple different items on a page use add clear, the clear anchor will be added multiple times to each item because it looks for the class and appends.

Using this and after makes the anchor only add to the item currently being set up.
