### PR TITLE
fixed the element wrapping for ie8 compatibility

### DIFF
--- a/addclear.js
+++ b/addclear.js
@@ -18,7 +18,7 @@
         hideOnBlur: false
       }, options);
 
-      $(this).wrap("<span style='position:relative;' class='add-clear-span'>");
+      $(this).wrap("<span style='position:relative;' class='add-clear-span'></span>");
       $(this).after("<a href='#clear'>"+options.closeSymbol+"</a>");
       $("a[href='#clear']").css({
         color: options.color,


### PR DESCRIPTION
I've fixed an issue found on IE8 where the span that wraps the input is not being applied producing wrong behavior. This happens because when calling the jquery wrap() method, the span doesn't have the </span> closing tab and this breaks the functionality in IE8 as it doesn't support HTML5. 
