### PR TITLE
Reformatted addclear.js to support multiple targets

### DIFF
--- a/addclear.js
+++ b/addclear.js
@@ -1,76 +1,105 @@
 // Author: Stephen Korecky
+// Modifications: @jameswragg
 // Website: http://stephenkorecky.com
 // Plugin Website: http://github.com/skorecky/Add-Clear
 
-(function($){
-  $.fn.extend({
-    addClear: function(options) {
-      var selector = this.selector;
+;(function($, window, document, undefined) {
 
-      var options =  $.extend({
-        closeSymbol: "&#10006;",
-        color: "#CCC",
-        top: 1,
-        right: 4,
-        returnFocus: true,
-        showOnLoad: false,
-        onClear: null,
-        hideOnBlur: false
-      }, options);
+	// Create the defaults once
+	var pluginName = "addClear",
+		defaults = {
+			closeSymbol: "&#10006;",
+			color: "#CCC",
+			top: 1,
+			right: 4,
+			returnFocus: true,
+			showOnLoad: false,
+			onClear: null,
+			hideOnBlur: false
+		};
 
-      $(this).wrap("<span style='position:relative;' class='add-clear-span'>");
-      $(this).after("<a href='#clear'>"+options.closeSymbol+"</a>");
-      $("a[href='#clear']").css({
-        color: options.color,
-        'text-decoration': 'none',
-        display: 'none',
-        'line-height': 1,
-        overflow: 'hidden',
-        position: 'absolute',
-        right: options.right,
-        top: options.top
-      }, this);
+	// The actual plugin constructor
+	function Plugin(element, options) {
+		this.element = element;
 
-      if($(this).val().length >= 1 && options.showOnLoad === true) {
-        $(this).siblings("a[href='#clear']").show();
-      }
+		this.options = $.extend({}, defaults, options);
 
-      $(this).focus(function() {
-        if($(this).val().length >= 1) {
-          $(this).siblings("a[href='#clear']").show();
-        }
-      });
+		this._defaults = defaults;
+		this._name = pluginName;
 
-      $(this).blur(function() {
-          var self = this;
+		this.init();
+	}
 
-          if (options.hideOnBlur) {
-              setTimeout(function () {
-                $(self).siblings("a[href='#clear']").hide();
-              }, 50);
-          }
-      });
+	Plugin.prototype = {
 
-      $(this).keyup(function() {
-        if($(this).val().length >= 1) {
-          $(this).siblings("a[href='#clear']").show();
-        } else {
-          $(this).siblings("a[href='#clear']").hide();
-        }
-      });
+		init: function() {
+			var $this = $(this.element),
+				me = this,
+				options = this.options;
 
-      $("a[href='#clear']").click(function(){
-        $(this).siblings(selector).val("");
-        $(this).hide();
-        if(options.returnFocus === true){
-          $(this).siblings(selector).focus();
-        }
-        if (options.onClear){
-          options.onClear($(this).siblings("input"));
-        }
-        return false;
-      });
-      return this;
-    }
-  });
-})(jQuery);
+			$this.wrap("<span style='position:relative;' class='add-clear-span'>");
+			$this.after($("<a href='#clear' style='display: none;'>" + options.closeSymbol + "</a>"))
+			$this.next().css({
+				color: options.color,
+				'text-decoration': 'none',
+				display: 'none',
+				'line-height': 1,
+				overflow: 'hidden',
+				position: 'absolute',
+				right: options.right,
+				top: options.top
+			}, this);
+
+			if ($this.val().length >= 1 && options.showOnLoad === true) {
+				$this.siblings("a[href='#clear']").show();
+			}
+
+			$this.focus(function() {
+				if ($(this).val().length >= 1) {
+					$(this).siblings("a[href='#clear']").show();
+				}
+			});
+
+			$this.blur(function() {
+				var self = this;
+
+				if (options.hideOnBlur) {
+					setTimeout(function() {
+						$(self).siblings("a[href='#clear']").hide();
+					}, 50);
+				}
+			});
+
+			$this.keyup(function() {
+				if ($(this).val().length >= 1) {
+					$(this).siblings("a[href='#clear']").show();
+				} else {
+					$(this).siblings("a[href='#clear']").hide();
+				}
+			});
+
+			$("a[href='#clear']").click(function(e) {
+				$(this).siblings(me.element).val("");
+				$(this).hide();
+				if (options.returnFocus === true) {
+					$(this).siblings(me.element).focus();
+				}
+				if (options.onClear) {
+					options.onClear($(this).siblings("input"));
+				}
+				e.preventDefault();
+			});
+		}
+
+	};
+
+	$.fn[pluginName] = function(options) {
+		return this.each(function() {
+			if (!$.data(this, "plugin_" + pluginName)) {
+				$.data(this, "plugin_" + pluginName,
+					new Plugin(this, options));
+			}
+		});
+	};
+
+})(jQuery, window, document);


### PR DESCRIPTION
Dropped the existing plugin into the basic jQuery boilerplate found here:
https://github.com/jquery-boilerplate/jquery-patterns/blob/master/patterns/jquery.basic.plugin-boilerplate.js

This allows addclear.js to be used on multiple matching targets.
