### PR TITLE
Added support for 'cut' and 'delete' via contextmenu

### DIFF
--- a/addclear.js
+++ b/addclear.js
@@ -111,6 +111,7 @@
 			    $this.off('keyup', handleUserInput);
 				$this.off('cut', handleUserInput);
 				handleInput = handleUserInput;
+				handleUserInput.call(this);
 			};
 
 			$this.on('keyup', handleUserInput);

--- a/addclear.js
+++ b/addclear.js
@@ -99,12 +99,31 @@
 				}
 			});
 
-			$this.keyup(function() {
+			var handleUserInput = function() {
 				if ($(this).val().length >= 1) {
 					$clearButton.css({display: 'block'});
 				} else {
 					$clearButton.css({display: 'none'});
 				}
+			};
+
+			var handleInput = function () {
+			    $this.off('keyup', handleUserInput);
+				$this.off('cut', handleUserInput);
+				handleInput = handleUserInput;
+			};
+
+			$this.on('keyup', handleUserInput);
+
+			$this.on('cut', function () {
+				var self = this;
+				setTimeout(function () {
+					handleUserInput.call(self);
+				}, 0);
+			});
+
+			$this.on('input', function () {
+				handleInput.call(this);
 			});
 
 			if (options.hideOnBlur) {


### PR DESCRIPTION
Hi Stephen,
it's me again. I have yet another pull request for 'Add-Clear'.
Today our tester discovered that the clear button in input fields of our application does not disappear when he clears an input fields by selecting 'cut' or 'delete' in the context menu of said field:
![contextmenu](https://cloud.githubusercontent.com/assets/1068491/12360025/a75a035c-bbb5-11e5-8ad9-89e452a59650.png)

Since we are using your plugin to add the clear button, I have added support for this particular use case.

This is primarily done by utilizing the ['input'](https://developer.mozilla.org/en-US/docs/Web/Events/input) event which of course is not support by the gold old Internet Explorer 8. To ensure that the plugin is still working in browsers which do not support 'input', I have kept the old 'keyup' method which is removed in modern browsers when the 'input' callback is called the first time. I also added a callback for the ['cut'](https://developer.mozilla.org/en-US/docs/Web/Events/cut) event which is also removed in the 'input' callback. So clearing the input field via 'cut' also works in older browers. Unfortunately I'm not able to support the 'delete' action without the 'input' event.

Please consider merging my commits. Thanks in advance.

Best regards,
Christian
