### PR TITLE
Add default padding and document IE/Edge pitfalls

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -79,4 +79,17 @@ $("input").addClear({
     <td>null</td>
     <td>function</td>
   </tr>
+  <tr>
+    <td>paddingRight</td>
+    <td>20px</td>
+    <td>string</td>
+  </tr>
 </table>
+
+### Note about Microsoft Browsers
+
+The more modern Microsoft browsers (IE10+ and Edge) have built-in clear buttons that appear
+automatically on text inputs. To prevent those buttons from interfering with Add Clear, you must
+use the `::-ms-clear` CSS pseudo-element in your styles, as described here:
+
+https://developer.mozilla.org/en-US/docs/Web/CSS/::-ms-clear

--- a/addclear.js
+++ b/addclear.js
@@ -40,7 +40,8 @@
 			showOnLoad: false,
 			onClear: null,
 			hideOnBlur: false,
-			tabbable: true
+			tabbable: true,
+			paddingRight: '20px'
 		};
 
 	// The actual plugin constructor
@@ -77,6 +78,12 @@
 				right: options.right,
 				top: options.top
 			}, this);
+
+			if (options.paddingRight) {
+				$this.css({
+					'padding-right': options.paddingRight
+				});
+			}
 
 			if ($this.val().length >= 1 && options.showOnLoad === true) {
 				$clearButton.css({display: 'block'});


### PR DESCRIPTION
Add the ability to pad the right side of the input field so that
entered text doesn't collide with the clear button. The default is
20px and can be overridden.

Add a section to the bottom of the README file with a note about the
built-in clear buttons in IE/Edge and a link to more info.

Tested with Chrome, IE11, Edge, and Firefox.